### PR TITLE
Add cog.yaml and predict.py for usage with Replicate and Docker

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,32 @@
+build:
+  gpu: true
+  cuda: "12.4"
+  python_version: "3.11"
+  system_packages:
+    - "libgl1-mesa-glx"
+    - "libglib2.0-0"
+    - "git"
+    - "ninja-build"
+    - "gcc-11"
+    - "g++-11"
+  python_packages:
+    - "torch==2.4.1"
+    - "torchvision==0.19.1"
+    - "torchaudio==2.4.1"
+    - "diffusers"
+    - "transformers"
+    - "accelerate"
+    - "sentencepiece"
+    - "protobuf"
+    - "huggingface_hub"
+    - "peft"
+    - "opencv-python"
+    - "einops"
+    - "gradio"
+    - "GPUtil"
+  run:
+    - "echo 'Cloning nunchaku repository'"
+    - "git clone https://github.com/mit-han-lab/nunchaku.git"
+    - "cd nunchaku && git submodule init && git submodule update"
+    - "cd nunchaku && pip install -e ."
+predict: "predict.py:Predictor"

--- a/example.py
+++ b/example.py
@@ -1,11 +1,33 @@
 import torch
+import time
 
 from nunchaku.pipelines import flux as nunchaku_flux
 
+# Initialize the pipeline
 pipeline = nunchaku_flux.from_pretrained(
     "black-forest-labs/FLUX.1-schnell",
+    cache_dir="model-cache",
     torch_dtype=torch.bfloat16,
     qmodel_path="mit-han-lab/svdquant-models/svdq-int4-flux.1-schnell.safetensors",  # download from Huggingface
 ).to("cuda")
-image = pipeline("A cat holding a sign that says hello world", num_inference_steps=4, guidance_scale=0).images[0]
-image.save("example.png")
+
+# List of prompts
+prompts = [
+    "A cat holding a sign that says hello world",
+    "A dog playing with a ball in the park",
+    "A beautiful sunset over the mountains",
+    "A futuristic cityscape at night",
+    "A group of people having a picnic in the park"
+]
+
+# Generate images and calculate average time per image
+total_time = 0
+for i, prompt in enumerate(prompts):
+    start_time = time.time()
+    image = pipeline(prompt, num_inference_steps=4, guidance_scale=0).images[0]
+    end_time = time.time()
+    image.save(f"example_{i}.png")
+    total_time += end_time - start_time
+
+average_time_per_image = total_time / len(prompts)
+print(f"Average time per image: {average_time_per_image:.2f} seconds")

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,71 @@
+import os
+import time
+import uuid
+from typing import List
+
+import torch
+from cog import BasePredictor, Input, Path
+from nunchaku.pipelines import flux as nunchaku_flux
+
+MODEL_ID = "black-forest-labs/FLUX.1-schnell"
+MODEL_CACHE = "model-cache"
+QUANT_MODEL_PATH = "mit-han-lab/svdq-int4-flux.1-schnell"
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        print("Loading FLUX pipeline...")
+        self.pipe = nunchaku_flux.from_pretrained(
+            MODEL_ID,
+            torch_dtype=torch.bfloat16,
+            qmodel_path=QUANT_MODEL_PATH,
+            # cache_dir=MODEL_CACHE,
+            # local_files_only=False,
+        )
+        self.pipe.enable_sequential_cpu_offload()
+
+    @torch.inference_mode()
+    def predict(
+        self,
+        prompt: str = Input(
+            description="Input prompt",
+            default="a photo of an astronaut riding a horse on mars",
+        ),
+        width: int = Input(
+            description="Width of output image",
+            default=1024,
+        ),
+        height: int = Input(
+            description="Height of output image",
+            default=1024,
+        ),
+        num_inference_steps: int = Input(
+            description="Number of denoising steps", ge=1, le=10, default=4
+        ),
+        seed: int = Input(
+            description="Random seed. Leave blank to randomize the seed", default=None
+        ),
+    ) -> List[Path]:
+        """Run a single prediction on the model"""
+        if seed is None:
+            seed = int.from_bytes(os.urandom(2), "big")
+        print(f"Using seed: {seed}")
+
+        generator = torch.Generator("cuda").manual_seed(seed)
+        
+        output = self.pipe(
+            prompt=prompt,
+            generator=generator,
+            width=width,
+            height=height,
+            num_inference_steps=num_inference_steps,
+        )
+
+        # Create unique filename using timestamp and UUID
+        timestamp = int(time.time())
+        random_id = str(uuid.uuid4())[:8]
+        output_path = f"/tmp/out-{timestamp}-{random_id}.jpg"
+        
+        output.images[0].save(output_path, format='JPEG', quality=95)
+        
+        return [Path(output_path)]


### PR DESCRIPTION
I'm not totally sure if you want to have this in your repository but I figured I'd make a pull request anyway.

This PR adds the necessary configuration and code to deploy the model on Replicate:
- Added `cog.yaml` with CUDA 12.4 and Python 3.11 setup
- Added `predict.py` with Replicate-compatible inference code
- Enhanced `example.py` with batch processing support

The implementation supports configurable image dimensions, inference steps, and seeds. Sequential CPU offloading is enabled by default for better memory management.

Let me know if you need any clarification or changes.