### PR TITLE
[MINOR] Fix: Avoid shape.is_contiguous() assertion by reconstructing output shape

### DIFF
--- a/src/Linear.cpp
+++ b/src/Linear.cpp
@@ -446,9 +446,9 @@ GEMM_W8A8::QuantizedActivation GEMM_W8A8::quantize(Tensor x, bool fuse_glu) {
 }
 
 Tensor GEMM_W8A8::forward_quant(QuantizedActivation qact) {
-    auto oshape = qact.act.shape;
-    oshape[-1] = out_features;
-    Tensor out = Tensor::allocate(oshape, this->dtype, qact.act.device());
+    auto shape = TensorShape(qact.act.shape.dataExtent);
+    shape[-1] = out_features;
+    Tensor out = Tensor::allocate(shape, this->dtype, qact.act.device());
     kernels::gemm_w8a8(qact.act, this->qweight, out, qact.ascales, this->wscales, this->bias);
 
     debug("gemm.out", out);


### PR DESCRIPTION
### 🔧 Fix: Use `TensorShape` to avoid non-contiguous shape assertion error in `GEMM_W8A8::forward_quant`

---

#### 📌 What
- Modified how the output tensor shape is constructed in `GEMM_W8A8::forward_quant`.
- Replaced direct shape mutation (`oshape[-1] = out_features`) with creation of a new `TensorShape` using `dataExtent`.

---

#### 🧠 Why
- When input tensor shape's `N` and `K` are not the same, modifying the shape directly caused an assertion failure in `Tensor::allocate()` due to `shape.is_contiguous()` check.
- This is because the shape was changed while still referencing the original `dataStride`, making it logically inconsistent.
- Creating a fresh `TensorShape` from `dataExtent` ensures the new shape is consistent and safely mutable.

---

#### 🛠️ How
```cpp
auto shape = TensorShape(qact.act.shape.dataExtent);
shape[-1] = out_features;
Tensor out = Tensor::allocate(shape, this->dtype, qact.act.device());
