### PR TITLE
Fix GPU memory allocation issues

### DIFF
--- a/nunchaku/models/transformers/transformer_flux.py
+++ b/nunchaku/models/transformers/transformer_flux.py
@@ -179,7 +179,8 @@ class NunchakuFluxTransformerBlocks(nn.Module):
         encoder_hidden_states = encoder_hidden_states.to(original_dtype).to(original_device)
 
         return encoder_hidden_states, hidden_states
-
+    def __del__(self):
+        self.m.reset()
 
 ## copied from diffusers 0.30.3
 def rope(pos: torch.Tensor, dim: int, theta: int) -> torch.Tensor:

--- a/nunchaku/models/transformers/transformer_sana.py
+++ b/nunchaku/models/transformers/transformer_sana.py
@@ -130,7 +130,8 @@ class NunchakuSanaTransformerBlocks(nn.Module):
             .to(original_dtype)
             .to(original_device)
         )
-
+    def __del__(self):
+        self.m.reset()
 
 class NunchakuSanaTransformer2DModel(SanaTransformer2DModel, NunchakuModelLoaderMixin):
     @classmethod


### PR DESCRIPTION
Previously, the following would not properly clear all memory:
```py
import gc, torch
del pipeline, transformer
torch.cuda.empty_cache()
```
This PR fixes that by resetting the internal quantized model state on `__del__` (please note this is not actually called until the ref count for the transformer is 0, but this matches the behaviour of other projects like diffusers)

Since this calls the full reset() method of ModuleWrapper, it may have unintended consequences if multiple models are loaded at once (it's probably fine though)