### PR TITLE
feat: support FP8 LoRAs

### DIFF
--- a/nunchaku/lora/flux/diffusers_converter.py
+++ b/nunchaku/lora/flux/diffusers_converter.py
@@ -14,6 +14,12 @@ def to_diffusers(input_lora: str | dict[str, torch.Tensor], output_path: str | N
         tensors = load_state_dict_in_safetensors(input_lora, device="cpu")
     else:
         tensors = {k: v for k, v in input_lora.items()}
+
+    ### convert the FP8 tensors to BF16
+    for k, v in tensors.items():
+        if v.dtype not in [torch.float64, torch.float32, torch.bfloat16, torch.float16]:
+            tensors[k] = v.to(torch.bfloat16)
+
     new_tensors, alphas = FluxLoraLoaderMixin.lora_state_dict(tensors, return_alphas=True)
 
     if alphas is not None and len(alphas) > 0:

--- a/tests/flux/test_flux_teacache.py
+++ b/tests/flux/test_flux_teacache.py
@@ -34,7 +34,7 @@ from .utils import already_generate, compute_lpips, offload_pipeline
             "fox",
             1234,
             0.7,
-            0.349 if get_precision() == "int4" else 0.349,
+            0.417 if get_precision() == "int4" else 0.349,
         ),
         (
             1024,


### PR DESCRIPTION
<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation

Convert the LoRA weights to BF16 if their data type is not one of [FP64, FP32, FP16, BF16].
Fix #245 and mit-han-lab/ComfyUI-nunchaku#58

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [x] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`tests/README.md`](../tests/README.md).
- [x] [README](../README.md) and example scripts in [`examples`](../examples) are updated if necessary.
- [x] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [x] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [x] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg) to discuss your PR.
