### PR TITLE
#265

### DIFF
--- a/examples/flux.1-dev-lora-to-diffusers.py
+++ b/examples/flux.1-dev-lora-to-diffusers.py
@@ -1,0 +1,41 @@
+from safetensors.torch import load_file, save_file
+import torch
+
+def map_lora_to_diffusers(state_dict):
+    new_state_dict = {}
+    for key, value in state_dict.items():
+        if "lora_unet_img_in" in key:
+            # 将键中的"lora_unet_img_in"替换为"transformer.input_blocks.0"
+            new_key = key.replace("lora_unet_img_in", "transformer.input_blocks.0")
+        elif "lora_unet_txt_in" in key:
+            # 将键中的"lora_unet_txt_in"替换为"transformer.text_blocks.0"
+            new_key = key.replace("lora_unet_txt_in", "transformer.text_blocks.0")
+        else:
+            new_key = key  # 保留所有其他键
+        new_state_dict[new_key] = value
+
+    print("Converted key count:", len(new_state_dict))
+    return new_state_dict
+
+def load_and_convert_lora(lora_path):
+    # 加载原始文件
+    state_dict = load_file(lora_path, device="cpu")
+    print("Original key count:", len(state_dict))
+    print("Original keys:", list(state_dict.keys())[:10])  # 打印前10个键
+    
+
+    converted_state_dict = map_lora_to_diffusers(state_dict)
+    output_path = lora_path.replace(".safetensors", "_converted.safetensors")
+    
+    # 保存为 safetensors 格式，优化元数据
+    save_file(converted_state_dict, output_path, metadata=None)
+    
+    # 验证保存后的文件大小
+    import os
+    print(f"Saved file size: {os.path.getsize(output_path) / 1024 / 1024:.2f} MB")
+    
+    return converted_state_dict
+
+# 调用
+lora_path = "path/to/your/lora.safetensors"
+converted_state_dict = load_and_convert_lora(lora_path)


### PR DESCRIPTION
<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation
 To solve  https://github.com/mit-han-lab/nunchaku/issues/265 , we give a script that can map from Lora to diffusers.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->
Add the script "examples/flux.1-dev-lora-to-diffusers.py". You can modify the lora path in the script to your own lora path, and then run the script to generate the corresponding converted lora weights in your lora path directory. The converted lora weights end with 'contentverted.safesensors'.
## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`tests/README.md`](../tests/README.md).
- [ ] [README](../README.md) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg) to discuss your PR.
