### PR TITLE
fix: allow offload=True when using cache by disabling offload on first transformer block

### DIFF
--- a/nunchaku/caching/diffusers_adapters/flux.py
+++ b/nunchaku/caching/diffusers_adapters/flux.py
@@ -1,5 +1,4 @@
 import functools
-import unittest
 
 from diffusers import DiffusionPipeline, FluxTransformer2DModel
 from torch import nn
@@ -35,17 +34,13 @@ def apply_cache_on_transformer(
             )
         ]
     )
-    dummy_single_transformer_blocks = nn.ModuleList()
+    transformer.cached_transformer_blocks = cached_transformer_blocks
 
     original_forward = transformer.forward
 
     @functools.wraps(original_forward)
     def new_forward(self, *args, **kwargs):
-        with (
-            unittest.mock.patch.object(self, "transformer_blocks", cached_transformer_blocks),
-            unittest.mock.patch.object(self, "single_transformer_blocks", dummy_single_transformer_blocks),
-        ):
-            return original_forward(*args, **kwargs)
+        return original_forward(*args, **kwargs)
 
     transformer.forward = new_forward.__get__(transformer)
     transformer._is_cached = True


### PR DESCRIPTION
issue #435 

This PR fixes a crash when using caching on the Flux transformer with offload=True. 

Previously, we injected our cache wrapper by temporarily patching out transformer.transformer_blocks and transformer.single_transformer_blocks using unittest.mock.patch.object. 

In offload mode, that masking prevented the C++ offload logic (which expects to see the real transformer_blocks vector) from working correctly, causing a segmentation fault on the second layer.