### PR TITLE
fix: segmentation fault when using FBcache with offload=True

### DIFF
--- a/examples/flux.1-dev-double_cache_offloading.py
+++ b/examples/flux.1-dev-double_cache_offloading.py
@@ -1,0 +1,28 @@
+import torch
+from diffusers import FluxPipeline
+
+from nunchaku import NunchakuFluxTransformer2dModel
+from nunchaku.caching.diffusers_adapters import apply_cache_on_pipe
+from nunchaku.utils import get_precision
+
+precision = get_precision()
+
+transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+    f"mit-han-lab/nunchaku-flux.1-dev/svdq-{precision}_r32-flux.1-dev.safetensors",
+    offload=True,
+)
+
+pipeline = FluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=torch.bfloat16
+).to("cuda")
+
+apply_cache_on_pipe(
+    pipeline,
+    use_double_fb_cache=True,
+    residual_diff_threshold_multi=0.09,
+    residual_diff_threshold_single=0.12,
+)
+
+image = pipeline(["A cat holding a sign that says hello world"], num_inference_steps=50).images[0]
+
+image.save(f"flux.1-dev-cache-{precision}.png")

--- a/nunchaku/csrc/flux.h
+++ b/nunchaku/csrc/flux.h
@@ -143,8 +143,16 @@ public:
         temb              = temb.contiguous();
         rotary_emb_single = rotary_emb_single.contiguous();
 
+        if (net->isOffloadEnabled()) {
+            net->single_transformer_blocks.at(idx)->loadLazyParams();
+        }
+
         Tensor result = net->single_transformer_blocks.at(idx)->forward(
             from_torch(hidden_states), from_torch(temb), from_torch(rotary_emb_single));
+
+        if (net->isOffloadEnabled()) {
+            net->single_transformer_blocks.at(idx)->releaseLazyParams();
+        }
 
         hidden_states = to_torch(result);
         Tensor::synchronizeDevice();

--- a/src/FluxModel.h
+++ b/src/FluxModel.h
@@ -189,6 +189,7 @@ public:
     std::vector<std::unique_ptr<FluxSingleTransformerBlock>> single_transformer_blocks;
 
     std::function<Tensor(const Tensor &)> residual_callback;
+    bool isOffloadEnabled() const { return offload; }
 
 private:
     bool offload;


### PR DESCRIPTION
 issue #435 
 
This change resolves a bug where applying FBCache on a transformer with offload=True would trigger a segmentation fault.



